### PR TITLE
Use `-f` flag to readlink

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -22,7 +22,7 @@
 
 set -e
 
-readonly ASPECTS_DIR="$(dirname "$(readlink "${BASH_SOURCE[0]}")")"
+readonly ASPECTS_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 readonly OUTPUT_GROUPS="compdb_files"
 
 readonly WORKSPACE="$(bazel info workspace)"


### PR DESCRIPTION
This flag makes `readlink` work even when the argument is not actually a symlink. Here's an example of its behavior:

```shell
$ cd /tmp
$ ls -l foo
ls: cannot access 'foo': No such file or directory
$ touch foo
$ readlink foo  # This call fails
$ echo $?
1
$ readlink -f foo  # This call succeeds
/tmp/foo
```